### PR TITLE
Add deep link to Octopus Deploy project from Release Table

### DIFF
--- a/.changeset/nine-swans-hang.md
+++ b/.changeset/nine-swans-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-octopus-deploy': minor
+---
+
+Added Deep link into Octopus Deploy project from the Release Table.

--- a/.changeset/red-cheetahs-invite.md
+++ b/.changeset/red-cheetahs-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-octopus-deploy': minor
+---
+
+Added support for octopus deploy spaces.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,7 @@
     "@backstage/plugin-microsoft-calendar": "workspace:^",
     "@backstage/plugin-newrelic": "workspace:^",
     "@backstage/plugin-newrelic-dashboard": "workspace:^",
+    "@backstage/plugin-octopus-deploy": "workspace:^",
     "@backstage/plugin-org": "workspace:^",
     "@backstage/plugin-pagerduty": "workspace:^",
     "@backstage/plugin-permission-react": "workspace:^",

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -41,6 +41,10 @@ import {
   isAzureDevOpsAvailable,
   isAzurePipelinesAvailable,
 } from '@backstage/plugin-azure-devops';
+import {
+  isOctopusDeployAvailable,
+  EntityOctopusDeployContent,
+} from '@backstage/plugin-octopus-deploy';
 import { EntityBadgesDialog } from '@backstage/plugin-badges';
 import {
   EntityAboutCard,
@@ -259,6 +263,10 @@ export const cicdContent = (
 
     <EntitySwitch.Case if={isAzurePipelinesAvailable}>
       <EntityAzurePipelinesContent defaultLimit={25} />
+    </EntitySwitch.Case>
+
+    <EntitySwitch.Case if={isOctopusDeployAvailable}>
+      <EntityOctopusDeployContent defaultLimit={25} />
     </EntitySwitch.Case>
 
     <EntitySwitch.Case>

--- a/plugins/octopus-deploy/.yarn-metadata.json
+++ b/plugins/octopus-deploy/.yarn-metadata.json
@@ -1,0 +1,67 @@
+{
+  "manifest": {
+    "name": "@backstage/plugin-octopus-deploy",
+    "version": "0.1.2-next.0",
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "license": "Apache-2.0",
+    "publishConfig": {
+      "access": "public",
+      "main": "dist/index.esm.js",
+      "types": "dist/index.d.ts"
+    },
+    "backstage": {
+      "role": "frontend-plugin"
+    },
+    "scripts": {
+      "start": "backstage-cli package start",
+      "build": "backstage-cli package build",
+      "lint": "backstage-cli package lint",
+      "test": "backstage-cli package test",
+      "clean": "backstage-cli package clean",
+      "prepack": "backstage-cli package prepack",
+      "postpack": "backstage-cli package postpack"
+    },
+    "dependencies": {
+      "@backstage/catalog-model": "workspace:^",
+      "@backstage/core-components": "workspace:^",
+      "@backstage/core-plugin-api": "workspace:^",
+      "@backstage/plugin-catalog-react": "workspace:^",
+      "@backstage/theme": "workspace:^",
+      "@material-ui/core": "^4.9.13",
+      "@material-ui/icons": "^4.9.1",
+      "@material-ui/lab": "4.0.0-alpha.61",
+      "react-use": "^17.2.4"
+    },
+    "peerDependencies": {
+      "react": "^16.13.1 || ^17.0.0"
+    },
+    "devDependencies": {
+      "@backstage/cli": "workspace:^",
+      "@backstage/core-app-api": "workspace:^",
+      "@backstage/dev-utils": "workspace:^",
+      "@backstage/test-utils": "workspace:^",
+      "@testing-library/jest-dom": "^5.10.1",
+      "@testing-library/react": "^12.1.3",
+      "@testing-library/user-event": "^14.0.0",
+      "@types/node": "*",
+      "cross-fetch": "^3.1.5",
+      "msw": "^1.0.0"
+    },
+    "files": ["dist"],
+    "_registry": "npm",
+    "_loc": "/Users/gchristie/Library/Caches/Yarn/v6/npm-@backstage-plugin-octopus-deploy-0.1.2-next.0-fb2194e2-9e4c-485e-9796-5af9e643d85b-1698031459061/node_modules/@backstage/plugin-octopus-deploy/package.json",
+    "readmeFilename": "README.md",
+    "readme": "# Octopus Deploy Plugin\n\nWelcome to the octopus-deploy plugin!\n\n## Features\n\n- Display the deployment status of the most recent releases for a project in Octopus Deploy straight from the Backstage catalog\n\n## Getting started\n\nThis plugin (currently) uses the Backstage proxy to securely communicate with the Octopus Deploy API.\n\nTo use it, you will need to generate an [API Key](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) within Octopus Deploy.\n\n1. Add the following to your app-config.yaml to enable the proxy:\n\n```\n// app-config.yaml\nproxy:\n  '/octopus-deploy':\n    target: '<your-octopus-server-url>'\n    headers:\n      X-Octopus-ApiKey: ${OCTOPUS_API_KEY}\n```\n\n2. Add the following to `EntityPage.tsx` to display Octopus Releases\n\n```\n// In packages/app/src/components/catalog/EntityPage.tsx\nimport {\n  isOctopusDeployAvailable\n  EntityOctopusDeployContent\n} from '@backstage/plugin-octopus-deploy';\n\nconst cicdContent = (\n    <EntitySwitch>\n      {/* other components... */}\n      <EntitySwitch.Case if={isOctopusDeployAvailable}>\n        <EntityOctopusDeployContent defaultLimit={25} />\n      </EntitySwitch.Case>\n    </EntitySwitch>\n)\n```\n\n3. Add `octopus.com/project-id` and optionally an `octopus.com/space-id` annotation in the catalog descriptor file.\n\nTo obtain a projects ID you will have to query the Octopus API. You can get the space ID from the projects url in the octopus deploy UI. In the future we'll add support for using a projects slug as well.\n\n```\n// catalog-info.yaml\napiVersion: backstage.io/v1alpha1\nkind: Component\nmetadata:\n  # ...\n  annotations:\n    octopus.com/project-id: Projects-102\nspec:\n  type: service\n```\n\nAll set, you will be able to see the plugin in action!\n",
+    "description": "Welcome to the octopus-deploy plugin!"
+  },
+  "artifacts": [],
+  "remote": {
+    "type": "copy",
+    "registry": "npm",
+    "hash": "accc15ad-d7b1-4d25-bc3f-4814c5fed529-1698034207182",
+    "reference": "/Users/gchristie/dev/backstage.idp/src/backstage/plugins/octopus-deploy"
+  },
+  "registry": "npm",
+  "hash": "accc15ad-d7b1-4d25-bc3f-4814c5fed529-1698034207182"
+}

--- a/plugins/octopus-deploy/README.md
+++ b/plugins/octopus-deploy/README.md
@@ -42,9 +42,9 @@ const cicdContent = (
 )
 ```
 
-3. Add `octopus.com/project-id` annotation in catalog descriptor file
+3. Add `octopus.com/project-id` and optionally an `octopus.com/space-id` annotation in the catalog descriptor file.
 
-To obtain a projects ID you will have to query the Octopus API. In the future we'll add support for using a projects slug as well.
+To obtain a projects ID you will have to query the Octopus API. You can get the space ID from the projects url in the octopus deploy UI. In the future we'll add support for using a projects slug as well.
 
 ```
 // catalog-info.yaml
@@ -58,4 +58,4 @@ spec:
   type: service
 ```
 
-All set , you will be able to see the plugin in action!
+All set, you will be able to see the plugin in action!

--- a/plugins/octopus-deploy/README.md
+++ b/plugins/octopus-deploy/README.md
@@ -23,6 +23,13 @@ proxy:
       X-Octopus-ApiKey: ${OCTOPUS_API_KEY}
 ```
 
+Optionally, also add the following section to your app-config.yaml if you wish to enable linking to the Project Release page in the Octopus Deploy UI from the footer of the Backstage Release Table. Typically this will be the server URL above without the /api postfix.
+
+```
+octopusdeploy:
+  webBaseUrl: "<your-octopus-web-url>"
+```
+
 2. Add the following to `EntityPage.tsx` to display Octopus Releases
 
 ```

--- a/plugins/octopus-deploy/config.d.ts
+++ b/plugins/octopus-deploy/config.d.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Config {
+  octopusdeploy?: {
+    /**
+     * Frontend Web UI Base URL for deep links to UI
+     * @visibility frontend
+     */
+    webBaseUrl?: string;
+  };
+}

--- a/plugins/octopus-deploy/package.json
+++ b/plugins/octopus-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-octopus-deploy",
-  "version": "0.1.1-next.1",
+  "version": "0.1.2-next.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/octopus-deploy/package.json
+++ b/plugins/octopus-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-octopus-deploy",
-  "version": "0.1.1-next.0",
+  "version": "0.1.1-next.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/octopus-deploy/package.json
+++ b/plugins/octopus-deploy/package.json
@@ -44,10 +44,13 @@
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "*",
+    "@typescript-eslint/parser": "^6.8.0",
     "cross-fetch": "^3.1.5",
     "msw": "^1.0.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/octopus-deploy/src/api/index.ts
+++ b/plugins/octopus-deploy/src/api/index.ts
@@ -59,6 +59,7 @@ const DEFAULT_PROXY_PATH_BASE = '/octopus-deploy';
 export interface OctopusDeployApi {
   getReleaseProgression(
     projectId: string,
+    spaceId: string | null,
     releaseHistoryCount: number,
   ): Promise<OctopusProgression>;
 }
@@ -81,9 +82,10 @@ export class OctopusDeployClient implements OctopusDeployApi {
 
   async getReleaseProgression(
     projectId: string,
+    spaceId: string | null,
     releaseHistoryCount: number,
   ): Promise<OctopusProgression> {
-    const url = await this.getApiUrl(projectId, releaseHistoryCount);
+    const url = await this.getApiUrl(projectId, spaceId, releaseHistoryCount);
 
     const response = await this.fetchApi.fetch(url);
 
@@ -106,11 +108,21 @@ export class OctopusDeployClient implements OctopusDeployApi {
     return responseJson;
   }
 
-  private async getApiUrl(projectId: string, releaseHistoryCount: number) {
+  private async getApiUrl(
+    projectId: string,
+    spaceId: string | null,
+    releaseHistoryCount: number,
+  ) {
     const proxyUrl = await this.discoveryApi.getBaseUrl('proxy');
     const queryParameters = new URLSearchParams({
       releaseHistoryCount: releaseHistoryCount.toString(),
     });
+    if (spaceId !== null)
+      return `${proxyUrl}${this.proxyPathBase}/${encodeURIComponent(
+        spaceId,
+      )}/projects/${encodeURIComponent(
+        projectId,
+      )}/progression?${queryParameters}`;
     return `${proxyUrl}${this.proxyPathBase}/projects/${encodeURIComponent(
       projectId,
     )}/progression?${queryParameters}`;

--- a/plugins/octopus-deploy/src/api/index.ts
+++ b/plugins/octopus-deploy/src/api/index.ts
@@ -17,6 +17,7 @@ import {
   createApiRef,
   DiscoveryApi,
   FetchApi,
+  ConfigApi,
 } from '@backstage/core-plugin-api';
 
 /** @public */
@@ -49,11 +50,30 @@ export type OctopusDeployment = {
 };
 
 /** @public */
+export type OctopusLinks = {
+  Self: string;
+  Web: string;
+};
+
+/** @public */
+export type OctopusProject = {
+  Name: string;
+  Slug: string;
+  Links: OctopusLinks;
+};
+
+/** @public */
+export type OctopusPluginConfig = {
+  WebUiBaseUrl: string;
+};
+
+/** @public */
 export const octopusDeployApiRef = createApiRef<OctopusDeployApi>({
   id: 'plugin.octopusdeploy.service',
 });
 
 const DEFAULT_PROXY_PATH_BASE = '/octopus-deploy';
+const WEB_UI_BASE_URL_CONFIG_KEY = 'octopusdeploy.webBaseUrl';
 
 /** @public */
 export interface OctopusDeployApi {
@@ -62,19 +82,27 @@ export interface OctopusDeployApi {
     spaceId: string | null,
     releaseHistoryCount: number,
   ): Promise<OctopusProgression>;
+  getProjectInfo(
+    projectId: string,
+    spaceId: string | null,
+  ): Promise<OctopusProject>;
+  getConfig(): Promise<OctopusPluginConfig>;
 }
 
 /** @public */
 export class OctopusDeployClient implements OctopusDeployApi {
+  private readonly configApi: ConfigApi;
   private readonly discoveryApi: DiscoveryApi;
   private readonly fetchApi: FetchApi;
   private readonly proxyPathBase: string;
 
   constructor(options: {
+    configApi: ConfigApi;
     discoveryApi: DiscoveryApi;
     fetchApi: FetchApi;
     proxyPathBase?: string;
   }) {
+    this.configApi = options.configApi;
     this.discoveryApi = options.discoveryApi;
     this.fetchApi = options.fetchApi;
     this.proxyPathBase = options.proxyPathBase ?? DEFAULT_PROXY_PATH_BASE;
@@ -126,5 +154,48 @@ export class OctopusDeployClient implements OctopusDeployApi {
     return `${proxyUrl}${this.proxyPathBase}/projects/${encodeURIComponent(
       projectId,
     )}/progression?${queryParameters}`;
+  }
+
+  async getProjectInfo(
+    projectId: string,
+    spaceId: string | null,
+  ): Promise<OctopusProject> {
+    const url = await this.getProjectApiUrl(projectId, spaceId);
+    const response = await this.fetchApi.fetch(url);
+
+    let responseJson;
+
+    try {
+      responseJson = await response.json();
+    } catch (e) {
+      responseJson = { releases: [] };
+    }
+
+    if (response.status !== 200) {
+      throw new Error(
+        `Error communicating with Octopus Deploy: ${
+          responseJson?.error?.title || response.statusText
+        }`,
+      );
+    }
+
+    return responseJson;
+  }
+
+  async getConfig(): Promise<OctopusPluginConfig> {
+    return {
+      WebUiBaseUrl: this.configApi.getString(WEB_UI_BASE_URL_CONFIG_KEY),
+    };
+  }
+
+  private async getProjectApiUrl(projectId: string, spaceId: string | null) {
+    const proxyUrl = await this.discoveryApi.getBaseUrl('proxy');
+    if (spaceId !== null)
+      return `${proxyUrl}${this.proxyPathBase}/${encodeURIComponent(
+        spaceId,
+      )}/projects/${encodeURIComponent(projectId)}`;
+    return `${proxyUrl}${this.proxyPathBase}/projects/${encodeURIComponent(
+      projectId,
+    )}`;
   }
 }

--- a/plugins/octopus-deploy/src/components/EntityPageOctopusDeploy/EntityPageOctopusDeploy.tsx
+++ b/plugins/octopus-deploy/src/components/EntityPageOctopusDeploy/EntityPageOctopusDeploy.tsx
@@ -15,17 +15,22 @@
  */
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useReleases } from '../../hooks/useReleases';
-import { getAnnotationFromEntity } from '../../utils/getAnnotationFromEntity';
+import {
+  getProjectIdAnnotationFromEntity,
+  getSpaceIdAnnotationFromEntity,
+} from '../../utils/getAnnotationFromEntity';
 import React from 'react';
 import { ReleaseTable } from '../ReleaseTable';
 
 export const EntityPageOctopusDeploy = (props: { defaultLimit?: number }) => {
   const { entity } = useEntity();
 
-  const projectId = getAnnotationFromEntity(entity);
+  const projectId = getProjectIdAnnotationFromEntity(entity);
+  const spaceId = getSpaceIdAnnotationFromEntity(entity);
 
   const { environments, releases, loading, error } = useReleases(
     projectId,
+    spaceId,
     props.defaultLimit ?? 3,
   );
 

--- a/plugins/octopus-deploy/src/components/EntityPageOctopusDeploy/EntityPageOctopusDeploy.tsx
+++ b/plugins/octopus-deploy/src/components/EntityPageOctopusDeploy/EntityPageOctopusDeploy.tsx
@@ -15,6 +15,8 @@
  */
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useReleases } from '../../hooks/useReleases';
+import { useProject } from '../../hooks/useProject';
+import { useConfig } from '../../hooks/useConfig';
 import {
   getProjectIdAnnotationFromEntity,
   getSpaceIdAnnotationFromEntity,
@@ -34,10 +36,16 @@ export const EntityPageOctopusDeploy = (props: { defaultLimit?: number }) => {
     props.defaultLimit ?? 3,
   );
 
+  const projectResult = useProject(projectId, spaceId);
+
+  const configResult = useConfig();
+
   return (
     <ReleaseTable
       environments={environments}
       releases={releases}
+      project={projectResult.project}
+      config={configResult.config}
       loading={loading}
       error={error}
     />

--- a/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
+++ b/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 import { Box, Typography } from '@material-ui/core';
-import { OctopusEnvironment, OctopusReleaseProgression } from '../../api';
+import {
+  OctopusEnvironment,
+  OctopusProject,
+  OctopusReleaseProgression,
+  OctopusPluginConfig,
+} from '../../api';
 
 import React from 'react';
 import {
+  BottomLink,
+  BottomLinkProps,
   ResponseErrorPanel,
   StatusAborted,
   StatusError,
@@ -33,6 +40,8 @@ import { OctopusDeployIcon } from '../OctopusDeployIcon';
 type ReleaseTableProps = {
   environments?: OctopusEnvironment[];
   releases?: OctopusReleaseProgression[];
+  project?: OctopusProject;
+  config?: OctopusPluginConfig;
   loading: boolean;
   error?: Error;
 };
@@ -93,6 +102,8 @@ export const getDeploymentStatusComponent = (state: string | undefined) => {
 export const ReleaseTable = ({
   environments,
   releases,
+  project,
+  config,
   loading,
   error,
 }: ReleaseTableProps) => {
@@ -130,24 +141,39 @@ export const ReleaseTable = ({
     })) ?? []),
   ];
 
+  const deepLink: BottomLinkProps | null =
+    project?.Links?.Web && config?.WebUiBaseUrl
+      ? {
+          link: `${config.WebUiBaseUrl}${project.Links.Web}`,
+          title: 'Go to project',
+          onClick: e => {
+            e.preventDefault();
+            window.open(`${config?.WebUiBaseUrl}${project?.Links.Web}`);
+          },
+        }
+      : null;
+
   return (
-    <Table
-      isLoading={loading}
-      columns={columns}
-      options={{
-        search: true,
-        paging: true,
-        pageSize: 5,
-        showEmptyDataSourceMessage: !loading,
-      }}
-      title={
-        <Box display="flex" alignItems="center">
-          <OctopusDeployIcon style={{ fontSize: 30 }} />
-          <Box mr={1} />
-          Octopus Deploy - Releases ({releases ? releases.length : 0})
-        </Box>
-      }
-      data={releases ?? []}
-    />
+    <Box>
+      <Table
+        isLoading={loading}
+        columns={columns}
+        options={{
+          search: true,
+          paging: true,
+          pageSize: 5,
+          showEmptyDataSourceMessage: !loading,
+        }}
+        title={
+          <Box display="flex" alignItems="center">
+            <OctopusDeployIcon style={{ fontSize: 30 }} />
+            <Box mr={1} />
+            Octopus Deploy - Releases ({releases ? releases.length : 0})
+          </Box>
+        }
+        data={releases ?? []}
+      />
+      {deepLink !== null && <BottomLink {...deepLink} />}
+    </Box>
   );
 };

--- a/plugins/octopus-deploy/src/constants.ts
+++ b/plugins/octopus-deploy/src/constants.ts
@@ -16,3 +16,4 @@
 
 /** @public */
 export const OCTOPUS_DEPLOY_PROJECT_ID_ANNOTATION = 'octopus.com/project-id';
+export const OCTOPUS_DEPLOY_SPACE_ID_ANNOTATION = 'octopus.com/space-id';

--- a/plugins/octopus-deploy/src/hooks/useConfig.ts
+++ b/plugins/octopus-deploy/src/hooks/useConfig.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useApi } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/lib/useAsync';
+import { octopusDeployApiRef, OctopusPluginConfig } from '../api';
+
+export function useConfig(): {
+  config?: OctopusPluginConfig;
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(octopusDeployApiRef);
+
+  const { value, loading, error } = useAsync(() => {
+    return api.getConfig();
+  }, [api]);
+
+  return {
+    config: value,
+    loading,
+    error,
+  };
+}

--- a/plugins/octopus-deploy/src/hooks/useProject.ts
+++ b/plugins/octopus-deploy/src/hooks/useProject.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useApi } from '@backstage/core-plugin-api';
+import useAsync from 'react-use/lib/useAsync';
+import { octopusDeployApiRef, OctopusProject } from '../api';
+
+export function useProject(
+  projectId: string,
+  spaceId: string | null,
+): {
+  project?: OctopusProject;
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(octopusDeployApiRef);
+
+  const { value, loading, error } = useAsync(() => {
+    return api.getProjectInfo(projectId, spaceId);
+  }, [api, projectId, spaceId]);
+
+  return {
+    project: value,
+    loading,
+    error,
+  };
+}

--- a/plugins/octopus-deploy/src/hooks/useReleases.ts
+++ b/plugins/octopus-deploy/src/hooks/useReleases.ts
@@ -23,6 +23,7 @@ import {
 
 export function useReleases(
   projectId: string,
+  spaceId: string | null,
   releaseHistoryCount: number,
 ): {
   environments?: OctopusEnvironment[];
@@ -33,8 +34,8 @@ export function useReleases(
   const api = useApi(octopusDeployApiRef);
 
   const { value, loading, error } = useAsync(() => {
-    return api.getReleaseProgression(projectId, releaseHistoryCount);
-  }, [api, projectId, releaseHistoryCount]);
+    return api.getReleaseProgression(projectId, spaceId, releaseHistoryCount);
+  }, [api, projectId, spaceId, releaseHistoryCount]);
 
   return {
     environments: value?.Environments,

--- a/plugins/octopus-deploy/src/index.ts
+++ b/plugins/octopus-deploy/src/index.ts
@@ -21,4 +21,7 @@ export {
 
 export * from './api';
 
-export { OCTOPUS_DEPLOY_PROJECT_ID_ANNOTATION } from './constants';
+export {
+  OCTOPUS_DEPLOY_PROJECT_ID_ANNOTATION,
+  OCTOPUS_DEPLOY_SPACE_ID_ANNOTATION,
+} from './constants';

--- a/plugins/octopus-deploy/src/plugin.ts
+++ b/plugins/octopus-deploy/src/plugin.ts
@@ -24,6 +24,7 @@ import {
   createRoutableExtension,
   discoveryApiRef,
   fetchApiRef,
+  configApiRef,
 } from '@backstage/core-plugin-api';
 
 import { Entity } from '@backstage/catalog-model';
@@ -38,9 +39,13 @@ export const octopusDeployPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: octopusDeployApiRef,
-      deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
-      factory: ({ discoveryApi, fetchApi }) =>
-        new OctopusDeployClient({ discoveryApi, fetchApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi, configApi }) =>
+        new OctopusDeployClient({ discoveryApi, fetchApi, configApi }),
     }),
   ],
 });

--- a/plugins/octopus-deploy/src/utils/getAnnotationFromEntity.ts
+++ b/plugins/octopus-deploy/src/utils/getAnnotationFromEntity.ts
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { OCTOPUS_DEPLOY_PROJECT_ID_ANNOTATION } from '../constants';
+import {
+  OCTOPUS_DEPLOY_PROJECT_ID_ANNOTATION,
+  OCTOPUS_DEPLOY_SPACE_ID_ANNOTATION,
+} from '../constants';
 
 import { Entity } from '@backstage/catalog-model';
 
-export function getAnnotationFromEntity(entity: Entity): string {
+export function getProjectIdAnnotationFromEntity(entity: Entity): string {
   const annotation =
     entity.metadata.annotations?.[OCTOPUS_DEPLOY_PROJECT_ID_ANNOTATION];
   if (!annotation) {
@@ -27,4 +30,11 @@ export function getAnnotationFromEntity(entity: Entity): string {
   }
 
   return annotation;
+}
+
+export function getSpaceIdAnnotationFromEntity(entity: Entity): string | null {
+  const annotation =
+    entity.metadata.annotations?.[OCTOPUS_DEPLOY_SPACE_ID_ANNOTATION];
+
+  return annotation || null;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7163,7 +7163,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-octopus-deploy@workspace:plugins/octopus-deploy":
+"@backstage/plugin-octopus-deploy@workspace:^, @backstage/plugin-octopus-deploy@workspace:plugins/octopus-deploy":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-octopus-deploy@workspace:plugins/octopus-deploy"
   dependencies:
@@ -7183,6 +7183,7 @@ __metadata:
     "@testing-library/react": ^12.1.3
     "@testing-library/user-event": ^14.0.0
     "@types/node": "*"
+    "@typescript-eslint/parser": ^6.8.0
     cross-fetch: ^3.1.5
     msw: ^1.0.0
     react-use: ^17.2.4
@@ -16549,6 +16550,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/parser@npm:^6.8.0":
+  version: 6.8.0
+  resolution: "@typescript-eslint/parser@npm:6.8.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": 6.8.0
+    "@typescript-eslint/types": 6.8.0
+    "@typescript-eslint/typescript-estree": 6.8.0
+    "@typescript-eslint/visitor-keys": 6.8.0
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10d7a3ae383fee5a5cba9541c72e23d6ab01cca6b414a62b44dacb5ebc15c80b80aa6c105b6469d3795f2f8514ae2499c069cd2d9dcac61f3db9ef6c7a75e080
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:5.53.0":
   version: 5.53.0
   resolution: "@typescript-eslint/scope-manager@npm:5.53.0"
@@ -16566,6 +16585,16 @@ __metadata:
     "@typescript-eslint/types": 5.9.0
     "@typescript-eslint/visitor-keys": 5.9.0
   checksum: 46e7ab0cef558e7faf1aa8d122a265e196566c0073292f5b2f9cede1f63f52860be8e4ef90251c15e0922339c15852584cb5337382035baff87f1203c0c8d1b5
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:6.8.0":
+  version: 6.8.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.8.0"
+  dependencies:
+    "@typescript-eslint/types": 6.8.0
+    "@typescript-eslint/visitor-keys": 6.8.0
+  checksum: b6cf2803531d1c14b56c30fd3cd807b80e17fe48d0da8e5aa9ae50915407ed732c7e2a7ac8030b7cf8ed07b8e481a1138d76bf05b727837a0e016280c2f6873b
   languageName: node
   linkType: hard
 
@@ -16597,6 +16626,13 @@ __metadata:
   version: 5.9.0
   resolution: "@typescript-eslint/types@npm:5.9.0"
   checksum: 7c4e142600aec266b41418dab1d0cee8cace980b6990692df6522de6eab6705bf515aef36180e4a38c62acb10c92fb474269ac6856a4266d6b035068cd83fad3
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.8.0":
+  version: 6.8.0
+  resolution: "@typescript-eslint/types@npm:6.8.0"
+  checksum: 1fcd85f6d575116d51c6ee757ed37610ae5e7e4296a29f93c9c6949f6cd16d24550eb7fc5bae7a43119cc08e13836f69a7ae7c54ebba6c95aef96b34d3bfb7f7
   languageName: node
   linkType: hard
 
@@ -16636,6 +16672,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:6.8.0":
+  version: 6.8.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.8.0"
+  dependencies:
+    "@typescript-eslint/types": 6.8.0
+    "@typescript-eslint/visitor-keys": 6.8.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 388db7f33ef1bc0e7b960c0bce9c744c2e32c66c7ab8dfae73d8533958202ad6f31663b0010f79c45b5ff93159c67f45b00693d73b9da2472b17156dfd26b4a8
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:5.53.0, @typescript-eslint/utils@npm:^5.10.0, @typescript-eslint/utils@npm:^5.43.0":
   version: 5.53.0
   resolution: "@typescript-eslint/utils@npm:5.53.0"
@@ -16671,6 +16725,16 @@ __metadata:
     "@typescript-eslint/types": 5.9.0
     eslint-visitor-keys: ^3.0.0
   checksum: 34a595b83b0e7d4f387d6c81b272804b94a1a91478c5f856fdfdd227595bf8562bf3f5d732606d10b4522c3f2617d09d4bacd2193f757a324ea66b3144a68903
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.8.0":
+  version: 6.8.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.8.0"
+  dependencies:
+    "@typescript-eslint/types": 6.8.0
+    eslint-visitor-keys: ^3.4.1
+  checksum: 710d9067b85d7715a400ae625c083c41733abb891d7b35108de083913980f9642e79d27689599fa39915f0fecae16dbfc30367007fccc838ccd917943660de22
   languageName: node
   linkType: hard
 
@@ -22754,10 +22818,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "eslint-visitor-keys@npm:3.3.0"
-  checksum: d59e68a7c5a6d0146526b0eec16ce87fbf97fe46b8281e0d41384224375c4e52f5ffb9e16d48f4ea50785cde93f766b0c898e31ab89978d88b0e1720fbfb7808
+"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 36e9ef87fca698b6fd7ca5ca35d7b2b6eeaaf106572e2f7fd31c12d3bfdaccdb587bba6d3621067e5aece31c8c3a348b93922ab8f7b2cbc6aaab5e1d89040c60
   languageName: node
   linkType: hard
 
@@ -23053,6 +23117,7 @@ __metadata:
     "@backstage/plugin-microsoft-calendar": "workspace:^"
     "@backstage/plugin-newrelic": "workspace:^"
     "@backstage/plugin-newrelic-dashboard": "workspace:^"
+    "@backstage/plugin-octopus-deploy": "workspace:^"
     "@backstage/plugin-org": "workspace:^"
     "@backstage/plugin-pagerduty": "workspace:^"
     "@backstage/plugin-permission-react": "workspace:^"
@@ -35811,7 +35876,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:~7.3.0":
+"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  languageName: node
+  linkType: hard
+
+"semver@npm:~7.3.0":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:
@@ -38041,6 +38117,15 @@ __metadata:
   version: 1.0.1
   resolution: "tryer@npm:1.0.1"
   checksum: 1cf14d7f67c79613f054b569bfc9a89c7020d331573a812dfcf7437244e8f8e6eb6893b210cbd9cc217f67c1d72617f89793df231e4fe7d53634ed91cf3a89d1
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "ts-api-utils@npm:1.0.3"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 441cc4489d65fd515ae6b0f4eb8690057add6f3b6a63a36073753547fb6ce0c9ea0e0530220a0b282b0eec535f52c4dfc315d35f8a4c9a91c0def0707a714ca6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have added a deep link into the Octopus Deploy project from the Release Page, in line with similar plugins.


![image](https://github.com/backstage/backstage/assets/1361894/ab14caf6-3c34-4104-8b1a-5cfe5fe544de)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ x ] Added or updated documentation
- [  ] Tests for new functionality and regression tests for bug fixes
- [ x ] Screenshots attached (for UI changes)
- [ x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

